### PR TITLE
Add `stderr` abstraction, add more tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: yrahul3910/zotero-rag
+          slug: zotero-rag/zotero-rag
           files: lcov.info
           fail_ci_if_error: true

--- a/zqa/src/common.rs
+++ b/zqa/src/common.rs
@@ -25,12 +25,13 @@ pub struct Args {
     pub model_provider: String,
 }
 
-/// A structure that holds the application context, including CLI arguments and an output writer.
-pub struct Context<O: Write, E: Write> {
+/// A structure that holds the application context, including CLI arguments and an writers
+/// for `stdout` and `stderr`.
+pub struct Context<OutStream: Write, ErrStream: Write> {
     // CLI arguments passed
     pub args: Args,
     // Abstraction for stdout()
-    pub out: O,
+    pub out: OutStream,
     // Abstraction for stderr()
-    pub err: E,
+    pub err: ErrStream,
 }

--- a/zqa/src/common.rs
+++ b/zqa/src/common.rs
@@ -26,9 +26,11 @@ pub struct Args {
 }
 
 /// A structure that holds the application context, including CLI arguments and an output writer.
-pub struct Context<W: Write> {
+pub struct Context<O: Write, E: Write> {
     // CLI arguments passed
     pub args: Args,
-    // Abstraction that can write stuff
-    pub out: W,
+    // Abstraction for stdout()
+    pub out: O,
+    // Abstraction for stderr()
+    pub err: E,
 }

--- a/zqa/src/main.rs
+++ b/zqa/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::stdout;
+use std::io::{stderr, stdout};
 
 use clap::Parser;
 use dotenv::dotenv;
@@ -35,6 +35,7 @@ pub async fn main() {
     let context = Context {
         args,
         out: stdout(),
+        err: stderr(),
     };
 
     if let Err(e) = cli(context).await {


### PR DESCRIPTION
This PR continues on the `Context` abstraction built previously, and adds another field for an `stderr` abstraction. This PR also adds a unit test for the `embed` function.