### PR TITLE
Add `stats()` test

### DIFF
--- a/rag/src/vector/lance.rs
+++ b/rag/src/vector/lance.rs
@@ -14,8 +14,9 @@ use lancedb::{
 };
 use std::{error::Error, fmt::Display, sync::Arc, vec::IntoIter};
 
+// Maintainers: ensure that `DB_URI` begins with `TABLE_NAME`
 const DB_URI: &str = "data/lancedb-table";
-const TABLE_NAME: &str = "data";
+pub const TABLE_NAME: &str = "data";
 
 /// Errors that can occur when working with LanceDB
 #[derive(Debug)]


### PR DESCRIPTION
This PR adds a unit test for the `db_statistics()` function exposed by the `rag` crate.