### PR TITLE
Add readline implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2120,12 @@ checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
@@ -2176,6 +2197,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.0.8",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -3944,6 +3976,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,6 +4637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rag"
 version = "0.1.0"
 dependencies = [
@@ -5097,6 +5160,28 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "rustyline"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fd9ca5ebc709e8535e8ef7c658eb51457987e48c98ead2be482172accc408d"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+ "utf8parse",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ryu"
@@ -6976,6 +7061,7 @@ dependencies = [
  "ratatui",
  "reqwest",
  "rusqlite",
+ "rustyline",
  "serde",
  "serde_json",
  "serial_test",

--- a/zqa/Cargo.toml
+++ b/zqa/Cargo.toml
@@ -24,6 +24,7 @@ lancedb = "0.15.0"
 ratatui = "0.29.0"
 crossterm = "0.29.0"
 clap = { version = "4.5.40", features = ["derive"] }
+rustyline = "16.0.0"
 
 [[bin]]
 name = "zqa"

--- a/zqa/src/cli/app.rs
+++ b/zqa/src/cli/app.rs
@@ -1,5 +1,6 @@
 use crate::cli::placeholder::PlaceholderText;
 use crate::cli::prompts::{get_extraction_prompt, get_summarize_prompt};
+use crate::cli::readline::get_readline_config;
 use crate::utils::arrow::vector_search;
 use arrow_array::{self, RecordBatch, RecordBatchIterator};
 use lancedb::embeddings::EmbeddingDefinition;
@@ -7,6 +8,8 @@ use rag::llm::base::{ApiClient, ApiResponse, ModelProviders, UserMessage};
 use rag::llm::errors::LLMError;
 use rag::llm::factory::get_client_by_provider;
 use rag::vector::lance::{create_initial_table, db_statistics};
+use rustyline::EditMode;
+use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
 use tokio::task::JoinSet;
 
@@ -306,7 +309,11 @@ pub async fn cli<O: Write, E: Write>(mut ctx: Context<O, E>) -> Result<(), CLIEr
     let history_path = home_dir.join(".zqa_history");
 
     // Create the `readline` "editor" with our `PlaceholderText` helper
-    let mut rl = rustyline::Editor::<PlaceholderText, rustyline::history::DefaultHistory>::new()?;
+    let mut rl =
+        rustyline::Editor::<PlaceholderText, rustyline::history::DefaultHistory>::with_config(
+            get_readline_config(),
+        )?;
+
     if rl.load_history(&history_path).is_err() {
         // TODO: Synchronize `log` and the `Context` out/err streams
         log::debug!("No previous history.");

--- a/zqa/src/cli/app.rs
+++ b/zqa/src/cli/app.rs
@@ -8,8 +8,6 @@ use rag::llm::base::{ApiClient, ApiResponse, ModelProviders, UserMessage};
 use rag::llm::errors::LLMError;
 use rag::llm::factory::get_client_by_provider;
 use rag::vector::lance::{create_initial_table, db_statistics};
-use rustyline::EditMode;
-use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
 use tokio::task::JoinSet;
 
@@ -319,10 +317,11 @@ pub async fn cli<O: Write, E: Write>(mut ctx: Context<O, E>) -> Result<(), CLIEr
         log::debug!("No previous history.");
     }
 
+    rl.set_helper(Some(PlaceholderText {
+        placeholder_text: "Type in a question or /help for options".to_string(),
+    }));
+
     loop {
-        rl.set_helper(Some(PlaceholderText {
-            placeholder_text: "Type in a question or /help for options".to_string(),
-        }));
         let readline = rl.readline(">>> ");
 
         match readline {

--- a/zqa/src/cli/errors.rs
+++ b/zqa/src/cli/errors.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use rag::llm::errors::LLMError;
+use rustyline::error::ReadlineError;
 
 use crate::utils;
 
@@ -10,6 +11,7 @@ pub enum CLIError {
     IOError(String),
     LLMError(String),
     MalformedBatchError,
+    ReadlineError(String),
 }
 
 impl std::error::Error for CLIError {}
@@ -20,6 +22,7 @@ impl std::fmt::Display for CLIError {
             Self::IOError(msg) => write!(f, "IO Error: {msg}"),
             Self::LLMError(msg) => write!(f, "Error communicating with the LLM: {msg}"),
             Self::MalformedBatchError => write!(f, "Malformed batch in batch_iter.bin"),
+            Self::ReadlineError(msg) => write!(f, "Error from the readline implementation: {msg}"),
         }
     }
 }
@@ -51,5 +54,11 @@ impl From<&arrow_schema::ArrowError> for CLIError {
 impl From<LLMError> for CLIError {
     fn from(value: LLMError) -> Self {
         Self::LLMError(value.to_string())
+    }
+}
+
+impl From<ReadlineError> for CLIError {
+    fn from(value: ReadlineError) -> Self {
+        Self::ReadlineError(value.to_string())
     }
 }

--- a/zqa/src/cli/mod.rs
+++ b/zqa/src/cli/mod.rs
@@ -2,3 +2,4 @@ pub mod app;
 pub mod errors;
 pub mod placeholder;
 pub mod prompts;
+pub mod readline;

--- a/zqa/src/cli/mod.rs
+++ b/zqa/src/cli/mod.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod errors;
+pub mod placeholder;
 pub mod prompts;

--- a/zqa/src/cli/placeholder.rs
+++ b/zqa/src/cli/placeholder.rs
@@ -1,0 +1,68 @@
+use rustyline::Helper;
+use rustyline::completion::Completer;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::{ValidationResult, Validator};
+
+/// A struct that will implement placeholder text using readline. The placeholder text itself is
+/// configurable, and the various `impl`s necessary to interface with `rustyline` (the readline
+/// implementation) handle the rest.
+pub struct PlaceholderText {
+    pub placeholder_text: String,
+}
+
+/// Handles completions for the `PlaceholderText` Helper. Note that for showing dimmed
+/// placeholders, we don't need to support completions at all.
+impl Completer for PlaceholderText {
+    type Candidate = String;
+
+    fn complete(
+        &self,
+        _line: &str,
+        _pos: usize,
+        _ctx: &rustyline::Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        Ok((0, Vec::new()))
+    }
+}
+
+/// Handles displaying hints for the `PlaceholderText` Helper. For our use case, we really only
+/// need to display the hint when there is no text entered by the user.
+impl Hinter for PlaceholderText {
+    type Hint = String;
+
+    fn hint(&self, _line: &str, pos: usize, _ctx: &rustyline::Context<'_>) -> Option<Self::Hint> {
+        match pos {
+            0 => Some(self.placeholder_text.clone()),
+            _ => None,
+        }
+    }
+}
+
+/// Handles highlighting for the placeholder text. This relies on ANSI escape codes. For a
+/// reference, see
+/// [Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#Control_Sequence_Introducer_commands).
+/// Alternatively, see `man 4 console_codes`, and search for "ECMA-48 CSI Sequences".
+impl Highlighter for PlaceholderText {
+    fn highlight<'l>(&self, line: &'l str, pos: usize) -> std::borrow::Cow<'l, str> {
+        const DIM_BACKGROUND: &str = "\x1b[2m";
+        const RESET: &str = "\x1b[0m";
+
+        match pos {
+            0 => format!("{DIM_BACKGROUND}{line}").into(),
+            _ => format!("{RESET}{line}").into(),
+        }
+    }
+}
+
+/// We do not have invalid scenarios for the simple placeholder text.
+impl Validator for PlaceholderText {
+    fn validate(
+        &self,
+        _ctx: &mut rustyline::validate::ValidationContext,
+    ) -> rustyline::Result<rustyline::validate::ValidationResult> {
+        Ok(ValidationResult::Valid(None))
+    }
+}
+
+impl Helper for PlaceholderText {}

--- a/zqa/src/cli/placeholder.rs
+++ b/zqa/src/cli/placeholder.rs
@@ -44,14 +44,11 @@ impl Hinter for PlaceholderText {
 /// [Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#Control_Sequence_Introducer_commands).
 /// Alternatively, see `man 4 console_codes`, and search for "ECMA-48 CSI Sequences".
 impl Highlighter for PlaceholderText {
-    fn highlight<'l>(&self, line: &'l str, pos: usize) -> std::borrow::Cow<'l, str> {
+    fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
         const DIM_BACKGROUND: &str = "\x1b[2m";
         const RESET: &str = "\x1b[0m";
 
-        match pos {
-            0 => format!("{DIM_BACKGROUND}{line}").into(),
-            _ => format!("{RESET}{line}").into(),
-        }
+        format!("{DIM_BACKGROUND}{hint}{RESET}").into()
     }
 }
 

--- a/zqa/src/cli/readline.rs
+++ b/zqa/src/cli/readline.rs
@@ -1,0 +1,150 @@
+use std::{env, fs, path::PathBuf};
+
+use rustyline::{Config, EditMode};
+
+pub fn get_readline_config() -> Config {
+    Config::builder().edit_mode(get_edit_mode()).build()
+}
+
+/// Get the edit mode (emacs or vi) from either the readline (GNU) or editline (BSD) configs. The
+/// preference is:
+///
+/// GNU readline: INPUTRC > ~/.inputrc > /etc/inputrc
+/// BSD editline: EDITRC > ./.editrc > ~/.editrc
+///
+/// # Returns
+///
+/// The current edit mode (emacs or vi)
+fn get_edit_mode() -> EditMode {
+    match env::consts::OS {
+        "windows" => EditMode::Emacs, // No standard on Windows
+        "macos" => match get_editrc_edit_mode() {
+            Some(mode) => mode,
+            _ => get_inputrc_edit_mode(),
+        },
+        "linux" => get_inputrc_edit_mode(),
+        _ => EditMode::Emacs,
+    }
+}
+
+/// Attempt to find an editline config by priority order.
+///
+/// # Returns
+///
+/// * If a config file can be found, a path to it
+/// * Otherwise, `None`
+fn find_editrc() -> Option<PathBuf> {
+    let cwd = env::current_dir().ok()?;
+    if cwd.join(".editrc").exists() {
+        return Some(cwd.join(".editrc"));
+    }
+
+    let home_dir = env::home_dir()?;
+    if home_dir.join(".editrc").exists() {
+        return Some(home_dir.join(".editrc"));
+    }
+
+    None
+}
+
+/// Attempt to get the edit mode from the editline config.
+///
+/// # Returns
+///
+/// * If either EDITRC or an editline config is found, then the edit mode that is set (or emacs if
+///   unset)
+/// * Otherwise, `None`
+fn get_editrc_edit_mode() -> Option<EditMode> {
+    if let Ok(mode) = env::var("EDITRC") {
+        if mode.trim() == "vi" {
+            return Some(EditMode::Vi);
+        }
+
+        return Some(EditMode::Emacs);
+    }
+
+    if let Some(editrc_path) = find_editrc() {
+        return match fs::read_to_string(editrc_path) {
+            Ok(contents) => {
+                let has_vi = contents
+                    .lines()
+                    .filter(|line| !line.starts_with('#'))
+                    .map(|line| line.trim())
+                    .filter(|line| *line == "bind -v")
+                    .count()
+                    > 0;
+
+                if has_vi {
+                    return Some(EditMode::Vi);
+                }
+                Some(EditMode::Emacs)
+            }
+            _ => None,
+        };
+    }
+
+    None
+}
+
+/// Attempt to find an readline config by priority order.
+///
+/// # Returns
+///
+/// * If a config file can be found, a path to it
+/// * Otherwise, `None`
+fn find_inputrc() -> Option<PathBuf> {
+    let home_dir = env::home_dir()?;
+    if home_dir.join(".inputrc").exists() {
+        return Some(home_dir.join(".inputrc"));
+    }
+
+    if PathBuf::from("/etc/inputrc").exists() {
+        return Some(PathBuf::from("/etc/inputrc"));
+    }
+
+    None
+}
+
+/// Attempt to get the edit mode from the readline config.
+///
+/// From `man 3 readline`:
+/// The name of this file is taken from the value of the INPUTRC environment
+/// variable.  If that variable is unset, the default is ~/.inputrc.  If that file  does not exist
+/// or cannot be read, readline looks for /etc/inputrc.
+///
+/// # Returns
+///
+/// * If either INPUTRC or a readline config is found, then the edit mode that is set (or emacs if
+///   unset)
+/// * Otherwise, `None`
+fn get_inputrc_edit_mode() -> EditMode {
+    if let Ok(mode) = env::var("INPUTRC") {
+        if mode.trim() == "vi" {
+            return EditMode::Vi;
+        }
+
+        return EditMode::Emacs;
+    }
+
+    if let Some(inputrc_path) = find_inputrc() {
+        return match fs::read_to_string(inputrc_path) {
+            Ok(contents) => {
+                let has_vi = contents
+                    .lines()
+                    .filter(|line| !line.starts_with('#'))
+                    .map(|line| line.trim())
+                    .filter(|line| *line == "set editing-mode vi" || *line == "set -o vi")
+                    .count()
+                    > 0;
+
+                if has_vi {
+                    return EditMode::Vi;
+                }
+                EditMode::Emacs
+            }
+            _ => EditMode::Emacs,
+        };
+    }
+
+    EditMode::Emacs
+}


### PR DESCRIPTION
This PR adds a `readline` implementation to the CLI. This relies on the `rustyline` crate, which provides the actual `readline` implementation, while we use its features to automatically gain a way to implement hints, history, and emacs/vim bindings.