### PR TITLE
Add tests for readline utilities, thousands-separator for tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5905,6 +5905,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7065,6 +7075,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "temp-env",
  "tokio",
 ]
 

--- a/zqa/Cargo.toml
+++ b/zqa/Cargo.toml
@@ -25,6 +25,7 @@ ratatui = "0.29.0"
 crossterm = "0.29.0"
 clap = { version = "4.5.40", features = ["derive"] }
 rustyline = "16.0.0"
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [[bin]]
 name = "zqa"

--- a/zqa/src/cli/readline.rs
+++ b/zqa/src/cli/readline.rs
@@ -281,16 +281,16 @@ mod tests {
     #[serial]
     fn test_get_inputrc_edit_mode() {
         let no_config = get_inputrc_edit_mode();
-        assert!(no_config.is_none());
+        assert_eq!(no_config, EditMode::Emacs);
 
         fs::write(".inputrc", "foo\nset editing-mode vi").unwrap();
         let with_vi_config = get_inputrc_edit_mode();
-        assert!(with_vi_config.is_some_and(|m| m == EditMode::Vi));
+        assert_eq!(with_vi_config, EditMode::Vi);
         fs::remove_file(".editrc").unwrap();
 
         fs::write(".inputrc", "foo").unwrap();
         let with_emacs_config = get_inputrc_edit_mode();
-        assert!(with_emacs_config.is_some_and(|m| m == EditMode::Emacs));
+        assert_eq!(with_emacs_config, EditMode::Emacs);
         fs::remove_file(".inputrc").unwrap();
     }
 }

--- a/zqa/src/cli/readline.rs
+++ b/zqa/src/cli/readline.rs
@@ -34,7 +34,7 @@ fn get_edit_mode() -> EditMode {
 /// * If a config file can be found, a path to it
 /// * Otherwise, `None`
 fn find_editrc() -> Option<PathBuf> {
-    if let Some(path) = env::var("EDITRC").map(PathBuf::from).ok() {
+    if let Ok(path) = env::var("EDITRC").map(PathBuf::from) {
         return Some(path);
     }
 
@@ -90,7 +90,7 @@ fn get_editrc_edit_mode() -> Option<EditMode> {
 /// * If a config file can be found, a path to it
 /// * Otherwise, `None`
 fn find_inputrc() -> Option<PathBuf> {
-    if let Some(path) = env::var("INPUTRC").map(PathBuf::from).ok() {
+    if let Ok(path) = env::var("INPUTRC").map(PathBuf::from) {
         return Some(path);
     }
 

--- a/zqa/src/cli/readline.rs
+++ b/zqa/src/cli/readline.rs
@@ -149,6 +149,7 @@ mod tests {
 
     use rustyline::EditMode;
     use serial_test::serial;
+    use temp_env;
 
     use crate::cli::readline::{
         find_editrc, find_inputrc, get_editrc_edit_mode, get_inputrc_edit_mode,
@@ -284,9 +285,9 @@ mod tests {
         assert_eq!(no_config, EditMode::Emacs);
 
         fs::write(".inputrc", "foo\nset editing-mode vi").unwrap();
-        let with_vi_config = get_inputrc_edit_mode();
+        let with_vi_config = temp_env::with_var("INPUTRC", Some(".inputrc"), get_inputrc_edit_mode);
         assert_eq!(with_vi_config, EditMode::Vi);
-        fs::remove_file(".editrc").unwrap();
+        fs::remove_file(".inputrc").unwrap();
 
         fs::write(".inputrc", "foo").unwrap();
         let with_emacs_config = get_inputrc_edit_mode();

--- a/zqa/src/utils/library.rs
+++ b/zqa/src/utils/library.rs
@@ -312,10 +312,7 @@ mod tests {
         dotenv().ok();
 
         if env::var("FAKE_CI").is_ok() {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::set_var("CI", "true") };
-
-            let lib_path = get_lib_path();
+            let lib_path = temp_env::with_vars([("CI", Some("true"))], get_lib_path);
 
             assert!(lib_path.is_some());
             let lib_path = lib_path.unwrap();
@@ -327,9 +324,6 @@ mod tests {
             let items = library_items.unwrap();
             assert!(!items.is_empty());
             assert_eq!(items.len(), 10);
-
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::remove_var("CI") };
         } else {
             panic!(concat!(
                 "You have enabled `test_toy_library_loaded_in_ci`, but ",


### PR DESCRIPTION
This PR adds unit tests for the `readline` utility functions, and formats the token counts displayed by `run_query` using thousands separators.